### PR TITLE
Fix deprecation of OpenSSL::Cipher::Cipher -> OpenSSL::Cipher

### DIFF
--- a/lib/ruby_rncryptor.rb
+++ b/lib/ruby_rncryptor.rb
@@ -1,5 +1,5 @@
 # RubyRNCryptor by Erik Wrenholt.
-# Based on data format described by Rob Napier 
+# Based on data format described by Rob Napier
 # https://github.com/RNCryptor/RNCryptor-Spec/blob/master/RNCryptor-Spec-v3.md
 # MIT License
 
@@ -19,9 +19,9 @@ class RubyRNCryptor
 		iv =				data[18,16]
 		cipher_text =		data[34,data.length-66]
 		hmac =				data[data.length-32,32]
-				
+
 		msg = version + options + encryption_salt + hmac_salt + iv + cipher_text
-		
+
 		# Verify password is correct. First try with correct encoding
 		hmac_key = PKCS5.pbkdf2_hmac_sha1(password, hmac_salt, 10000, 32)
 		verified = eql_time_cmp([HMAC.hexdigest('sha256', hmac_key, msg)].pack('H*'), hmac)
@@ -32,11 +32,11 @@ class RubyRNCryptor
 			hmac_key = PKCS5.pbkdf2_hmac_sha1(password, hmac_salt, 10000, 32)
 			verified = eql_time_cmp([HMAC.hexdigest('sha256', hmac_key, msg)].pack('H*'), hmac)
 		end
-		
+
 		raise "Password may be incorrect, or the data has been corrupted. (HMAC could not be verified)" unless verified
-		
+
 		# HMAC was verified, now decrypt it.
-		cipher = Cipher::Cipher.new('aes-256-cbc')
+		cipher = Cipher.new('aes-256-cbc')
 		cipher.decrypt
 		cipher.iv = iv
 		cipher.key = PKCS5.pbkdf2_hmac_sha1(password, encryption_salt, 10000, 32)
@@ -47,7 +47,7 @@ class RubyRNCryptor
 	def self.encrypt(data, password, version = 3)
 
 		raise "RubyRNCryptor only encrypts version 2 or 3" unless (version == 2 || version == 3)
-		
+
 		version =			version.chr.to_s		# Currently version 3
 		options =			1.chr.to_s				# Uses password
 		encryption_salt =	SecureRandom.random_bytes(8)
@@ -56,8 +56,8 @@ class RubyRNCryptor
 		cipher_text =		data[34,data.length-66]
 
 		hmac_key = PKCS5.pbkdf2_hmac_sha1(password, hmac_salt, 10000, 32)
-		
-		cipher = Cipher::Cipher.new('aes-256-cbc')
+
+		cipher = Cipher.new('aes-256-cbc')
 		cipher.encrypt
 		cipher.iv = iv
 		cipher.key = PKCS5.pbkdf2_hmac_sha1(password, encryption_salt, 10000, 32)
@@ -75,7 +75,7 @@ class RubyRNCryptor
 		end
 		str.bytes.to_a[0...str.length].map {|c| c.chr}.join
 	end
-	
+
 	# From http://ruby-doc.org/stdlib-2.0.0/libdoc/openssl/rdoc/OpenSSL/PKCS5.html#module-OpenSSL::PKCS5-label-Important+Note+on+Checking+Passwords
 	def self.eql_time_cmp(a, b)
 		unless a.length == b.length


### PR DESCRIPTION
Resolves deprecation warning:
```
warning: constant OpenSSL::Cipher::Cipher is deprecated
```

Use OpenSSL::Cipher instead.
Looks like OpenSSL::Cipher.new (as opposed to OpenSSL::Cipher::Cipher.new) is supported at least back to Ruby 2.0.0 based on this doc:

https://ruby-doc.org/stdlib-2.0.0/libdoc/openssl/rdoc/OpenSSL/Cipher.html